### PR TITLE
Fix potential deadlock by invoking FabricBlockEntityPositionManager#getHolder

### DIFF
--- a/core/src/main/java/com/communi/suggestu/scena/core/entity/block/BlockEntityChunkStorage.java
+++ b/core/src/main/java/com/communi/suggestu/scena/core/entity/block/BlockEntityChunkStorage.java
@@ -1,0 +1,21 @@
+package com.communi.suggestu.scena.core.entity.block;
+
+import net.minecraft.world.level.chunk.ChunkAccess;
+
+/***
+ * Storage for saving {@link ChunkAccess} at chunk loading stage
+ */
+public interface BlockEntityChunkStorage {
+
+    /***
+     * Store {@link ChunkAccess} that owns {@link net.minecraft.world.level.block.entity.BlockEntity}
+     * @param access {@link ChunkAccess} to save
+     */
+    void setOwnerChunk(ChunkAccess access);
+
+    /***
+     * Get {@link ChunkAccess} that owns {@link net.minecraft.world.level.block.entity.BlockEntity}
+     * @return {@link ChunkAccess} that owns {@link net.minecraft.world.level.block.entity.BlockEntity}
+     */
+    ChunkAccess getOwnerChunk();
+}

--- a/fabric/src/main/java/com/communi/suggestu/scena/fabric/mixin/platform/common/BlockEntityMixin.java
+++ b/fabric/src/main/java/com/communi/suggestu/scena/fabric/mixin/platform/common/BlockEntityMixin.java
@@ -1,0 +1,25 @@
+package com.communi.suggestu.scena.fabric.mixin.platform.common;
+
+import com.communi.suggestu.scena.core.entity.block.BlockEntityChunkStorage;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+
+@Mixin(BlockEntity.class)
+public abstract class BlockEntityMixin implements BlockEntityChunkStorage {
+
+    @Unique
+    private ChunkAccess chunk;
+
+    @Override
+    public ChunkAccess getOwnerChunk() {
+        return chunk;
+    }
+
+    @Override
+    public void setOwnerChunk(ChunkAccess access) {
+        this.chunk = access;
+    }
+
+}

--- a/fabric/src/main/java/com/communi/suggestu/scena/fabric/mixin/platform/common/LevelChunkMixin.java
+++ b/fabric/src/main/java/com/communi/suggestu/scena/fabric/mixin/platform/common/LevelChunkMixin.java
@@ -1,7 +1,10 @@
 package com.communi.suggestu.scena.fabric.mixin.platform.common;
 
+import com.communi.suggestu.scena.core.entity.block.BlockEntityChunkStorage;
 import com.communi.suggestu.scena.fabric.platform.entity.IFabricBlockEntityPositionHolder;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.ProtoChunk;
 import org.spongepowered.asm.mixin.Mixin;
@@ -23,4 +26,11 @@ public class LevelChunkMixin {
         holder.scena$getBlockEntityPositions().clear();
         holder.scena$getBlockEntityPositions().putAll(protoHolder.scena$getBlockEntityPositions());
     }
+
+    @Inject(method = "setBlockEntity", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/level/block/entity/BlockEntity;setLevel(Lnet/minecraft/world/level/Level;)V", shift = At.Shift.BEFORE))
+    private void onSetBlockEntity(BlockEntity blockEntity, CallbackInfo ci){
+        BlockEntityChunkStorage chunkStorage = (BlockEntityChunkStorage) blockEntity;
+        chunkStorage.setOwnerChunk((ChunkAccess) (Object) this);
+    }
+
 }

--- a/fabric/src/main/java/com/communi/suggestu/scena/fabric/platform/entity/FabricBlockEntityPositionManager.java
+++ b/fabric/src/main/java/com/communi/suggestu/scena/fabric/platform/entity/FabricBlockEntityPositionManager.java
@@ -1,5 +1,6 @@
 package com.communi.suggestu.scena.fabric.platform.entity;
 
+import com.communi.suggestu.scena.core.entity.block.BlockEntityChunkStorage;
 import com.communi.suggestu.scena.core.entity.block.IBlockEntityPositionManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
@@ -26,6 +27,11 @@ public class FabricBlockEntityPositionManager implements IBlockEntityPositionMan
         return (IFabricBlockEntityPositionHolder) level.getChunk(chunkPos.x, chunkPos.z, ChunkStatus.FULL, false);
     }
 
+    @Nullable
+    private IFabricBlockEntityPositionHolder getHolder(BlockEntity blockEntity){
+        return (IFabricBlockEntityPositionHolder) ((BlockEntityChunkStorage) blockEntity).getOwnerChunk();
+    }
+
     @Override
     public Set<BlockPos> getPositions(Class<? extends BlockEntity> blockEntityClass, LevelReader level, ChunkPos chunkPos) {
         final IFabricBlockEntityPositionHolder holder = getHolder(level, chunkPos);
@@ -41,7 +47,11 @@ public class FabricBlockEntityPositionManager implements IBlockEntityPositionMan
         if (blockEntity.getLevel() == null)
             throw new IllegalArgumentException("Block entity must be in a level to be added to the position manager");
 
-        final IFabricBlockEntityPositionHolder holder = getHolder(blockEntity.getLevel(), new ChunkPos(blockEntity.getBlockPos()));
+        final IFabricBlockEntityPositionHolder holder = getHolder(blockEntity);
+        if(holder == null){
+            getHolder(blockEntity.getLevel(), new ChunkPos(blockEntity.getBlockPos()));
+        }
+
         if (holder == null) {
             return;
         }
@@ -54,7 +64,11 @@ public class FabricBlockEntityPositionManager implements IBlockEntityPositionMan
         if (blockEntity.getLevel() == null)
             throw new IllegalArgumentException("Block entity must be in a level to be removed from the position manager");
 
-        final IFabricBlockEntityPositionHolder holder = getHolder(blockEntity.getLevel(), new ChunkPos(blockEntity.getBlockPos()));
+        IFabricBlockEntityPositionHolder holder = getHolder(blockEntity);
+        if(holder == null){
+            holder = getHolder(blockEntity.getLevel(), new ChunkPos(blockEntity.getBlockPos()));
+        }
+
         if (holder == null) {
             return;
         }

--- a/fabric/src/main/resources/scena.mixins.json
+++ b/fabric/src/main/resources/scena.mixins.json
@@ -4,6 +4,7 @@
   "package": "com.communi.suggestu.scena.fabric.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
+    "platform.common.BlockEntityMixin",
     "platform.common.ChunkAccessMixin",
     "platform.common.ChunkMapChunkLoadMixin",
     "platform.common.ItemEntityEventMixin",


### PR DESCRIPTION
Described in more detail at https://github.com/ChiselsAndBits/Chisels-and-Bits/issues/1216

If a mod tries to invoke IBlockEntityPositionManager#add in BlockEntity#setLevel method, this may cause deadlock.

Making a block entity store its chunk when LevelChunk#setBlockEntity called and using it  on FabricBlockEntityPositionManager#getHolder solves the issue.

Original FabricBlockEntityPositionManager#getHolder tries to fetch chunk from LevelReader, which might be currently loading and  it can cause deadlock.

So we need to store a chunk that "will be" loaded in future to anywhere and take it from block entity when it needs. 